### PR TITLE
throw ENOENT when file is not found

### DIFF
--- a/js/jsx.js
+++ b/js/jsx.js
@@ -53,7 +53,7 @@ define(['JSXTransformer', 'text'], function (JSXTransformer, text) {
       };
 
       onLoad.error = function(err) {
-        throw(err);
+        onLoadNative.error(err);
       };
 
       text.load(name + fileExtension, req, onLoad, config);


### PR DESCRIPTION
When trying to load a not-existing-file in node environment, currently the script does nothing, it simply hangs (in the browser xhr correctly throws 404).

This PR throws the ENOENT error raised by `fs.readFileSync` in require.text.js.
